### PR TITLE
Fix typos in bash_task's _run_as method

### DIFF
--- a/lightflow/tasks/bash_task.py
+++ b/lightflow/tasks/bash_task.py
@@ -328,7 +328,7 @@ class BashTask(BaseTask):
         """ Function wrapper that sets the user and group for the process """
         def wrapper():
             if user is not None:
-                os.setgid(user)
+                os.setuid(user)
             if group is not None:
-                os.setuid(group)
+                os.setgid(group)
         return wrapper


### PR DESCRIPTION
os.setuid and os.setgid functions expect user_id and group_id respectively but the arguments were transposed.