### PR TITLE
Ensure we install networkx 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'celery>=4.0.2',
         'click>=6.7',
         'colorlog>=2.10.0',
-        'networkx>=1.11',
+        'networkx>=1.11,<2',
         'pymongo>=3.4.0',
         'pytz>=2016.10',
         'redis>=2.10.5',


### PR DESCRIPTION
networkx 2.0 has breaking API changes which will require updates to lightflow.

https://networkx.github.io/documentation/stable/release/release_2.0.html