### PR TITLE
added pw to signal

### DIFF
--- a/lightflow/config.py
+++ b/lightflow/config.py
@@ -231,6 +231,7 @@ celery:
 signal:
   host: localhost
   port: 6379
+  password: NULL
   database: 0
   polling_time: 0.5
 

--- a/lightflow/models/signal.py
+++ b/lightflow/models/signal.py
@@ -8,7 +8,7 @@ SIGNAL_REDIS_PREFIX = 'lightflow'
 
 class SignalConnection:
     """ The connection to the redis signal broker database. """
-    def __init__(self, host, port, database, *, auto_connect=False, polling_time=0.5):
+    def __init__(self, host, port, database, password, *, auto_connect=False, polling_time=0.5):
         """ Initialise the SignalConnection object.
 
         Args:
@@ -21,6 +21,7 @@ class SignalConnection:
         self._host = host
         self._port = port
         self._database = database
+        self._password = password
         self._polling_time = polling_time
 
         self._connection = None
@@ -47,7 +48,8 @@ class SignalConnection:
         self._connection = StrictRedis(
             host=self._host,
             port=self._port,
-            db=self._database)
+            db=self._database,
+            password=self._password)
 
 
 class Request:


### PR DESCRIPTION
Our redis is password protected. This is just a suggestion. Should we allow for passing passwords to `signal`?

My lightflow.cfg file now has something like:
```py3
celery:
redis://:xxxxx@cmb03.cs.nsls2.local:6379/0
  broker_url: redis://:xxxxx@cmb03:6379/0
  result_backend: redis://:xxxxx@cmb03:6379/0
  worker_concurrency: 8
  result_expires: 0
  worker_send_task_events: True
  worker_prefetch_multiplier: 1
signal:
  host: cmb03
  port: 6379
  password: xxxxx
  database: 0
  polling_time: 0.5 
```