### PR TITLE
updated for networkx 2.1

### DIFF
--- a/lightflow/models/dag.py
+++ b/lightflow/models/dag.py
@@ -133,7 +133,7 @@ class Dag:
         for task in nx.topological_sort(graph):
             task.workflow_name = self.workflow_name
             task.dag_name = self.name
-            if len(graph.predecessors(task)) == 0:
+            if len(list(graph.predecessors(task))) == 0:
                 task.state = TaskState.Waiting
                 tasks.append(task)
 
@@ -166,7 +166,7 @@ class Dag:
                     if stopped:
                         task.state = TaskState.Stopped
                     else:
-                        pre_tasks = graph.predecessors(task)
+                        pre_tasks = list(graph.predecessors(task))
                         if all([p.is_completed for p in pre_tasks]):
 
                             # check whether the task should be skipped

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'celery>=4.0.2',
         'click>=6.7',
         'colorlog>=2.10.0',
-        'networkx>=1.11,<2',
+        'networkx',
         'pymongo>=3.6.0',
         'pytz>=2016.10',
         'redis>=2.10.5',


### PR DESCRIPTION
We need support for networkx 2.1 or greater. I ran the workflow with networkx 2.1 and found I only needed these changes.

Changes: 
`graph.successors()` and `graph.predecessors()` are now iterators not lists. Where needed, I convert them back to lists.
Note I only converted some, where `len` was called on.
For the items that were iterated on, I left as is.

How I tested

This works for me, and I tested on the `branching.py`, `sub_dag.py` and `decision.py` and `simple.py` workflows.


We might want to consider adding a test.
One  simple test suffices, roughly, assert this doesn't raise:
```py3
import networkx as nx
graph = nx.DiGraph()
graph.add_node('foo')
graph.add_node('foo2')

len(list(graph.predecessors('foo')))
len(list(graph.successors('foo')))
```

However, we might want to simulate an actual workflow in a test. Might be worth giving this a shot?