### PR TITLE
Do not execute make_graph function again after define function in Dag class

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-pytest
+pytest>=3.6
 pytest-cov
 flake8


### PR DESCRIPTION
I believe it's worth that keeping graph defined already as an attribute of Dag class. Since in most of those cases, people would define graph firstly. Thus, it would take redundant moves if we execute make_graph() again.